### PR TITLE
Token ending with LF and no CR are valid

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1431,12 +1431,12 @@ static int validateAuthToken (str_t s) {
         if( p==s || c != ':' || p[0] != ' ' )
             return 0;
         s = ++p;
-        while( (c=*p++) != '\r' && c != 0 );
-        if( p==s || c==0 || p[0] != '\n' )
+        while( (c=*p++) != '\n' && c != 0 );
+        if( p==s || c==0 )
             return 0;
-        if( p[1] == 0 )
+        if( p[0] == 0 )
             return 1;
-        s = p = p+1;  // next line
+        s = p;  // next line
     }
 }
 


### PR DESCRIPTION
When the tc/cups.key file is used without a cert, http headers are expected, to specify for example a token.
As stated by the [doc](https://doc.sm.tc/station/authmodes.html?highlight=token#tls-server-authentication-and-client-token), one header by line is accepted and the lines must be ended with CRLF.

As the Basic Station is also intended to work on unix system, this PR allows for LF-only line ending too as commonly used in unix systems.