### PR TITLE
Beacons have wrong settings

### DIFF
--- a/src/ral_lgw.c
+++ b/src/ral_lgw.c
@@ -192,10 +192,17 @@ int ral_tx (txjob_t* txjob, s2ctx_t* s2ctx, int nocca) {
     struct lgw_pkt_tx_s pkt_tx;
     memset(&pkt_tx, 0, sizeof(pkt_tx));
 
+    pkt_tx.invert_pol = true;
+    pkt_tx.no_crc     = !txjob->addcrc;
+    pkt_tx.no_header  = false;
+
     if( txjob->preamble == 0 ) {
         if( txjob->txflags & TXFLAG_BCN ) {
             pkt_tx.tx_mode = ON_GPS;
             pkt_tx.preamble = 10;
+            pkt_tx.invert_pol = false;
+            pkt_tx.no_crc = true;
+            pkt_tx.no_header = true;
         } else {
             pkt_tx.tx_mode = TIMESTAMPED;
             pkt_tx.preamble = 8;
@@ -210,9 +217,6 @@ int ral_tx (txjob_t* txjob, s2ctx_t* s2ctx, int nocca) {
     pkt_tx.rf_chain   = 0;
     pkt_tx.rf_power   = (float)(txjob->txpow - txpowAdjust) / TXPOW_SCALE;
     pkt_tx.coderate   = CR_LORA_4_5;
-    pkt_tx.invert_pol = true;
-    pkt_tx.no_crc     = !txjob->addcrc;
-    pkt_tx.no_header  = false;
     pkt_tx.size       = txjob->len;
     memcpy(pkt_tx.payload, &s2ctx->txq.txdata[txjob->off], pkt_tx.size);
 

--- a/src/ral_lgw2.c
+++ b/src/ral_lgw2.c
@@ -193,10 +193,17 @@ u1_t ral_altAntennas (u1_t txunit) {
 int ral_tx (txjob_t* txjob, s2ctx_t* s2ctx, int nocca) {
     sx1301ar_tx_pkt_t pkt_tx = sx1301ar_init_tx_pkt();
 
+    pkt_tx.invert_pol = true;
+    pkt_tx.no_crc     = !txjob->addcrc;
+    pkt_tx.no_header  = false;
+
     if( txjob->preamble == 0 ) {
         if( txjob->txflags & TXFLAG_BCN ) {
             pkt_tx.tx_mode = TX_ON_GPS;
             pkt_tx.preamble = 10;
+            pkt_tx.invert_pol = false;
+            pkt_tx.no_crc = true;
+            pkt_tx.no_header = true;
         } else {
             pkt_tx.tx_mode = TX_TIMESTAMPED;
             pkt_tx.preamble = 8;
@@ -211,9 +218,6 @@ int ral_tx (txjob_t* txjob, s2ctx_t* s2ctx, int nocca) {
     pkt_tx.rf_chain   = 0;  
     pkt_tx.rf_power   = (float)(txjob->txpow - txpowAdjust) / TXPOW_SCALE;
     pkt_tx.coderate   = CR_4_5;
-    pkt_tx.invert_pol = true;
-    pkt_tx.no_crc     = !txjob->addcrc;
-    pkt_tx.no_header  = false;
     pkt_tx.size = txjob->len;
     memcpy(pkt_tx.payload, &s2ctx->txq.txdata[txjob->off], pkt_tx.size);
 


### PR DESCRIPTION
This solves the problem of devices not receiving beacons (as discussed in #129 ). Per the regional parameters specs for 1.0.3 and 1.1 beacon radio frames should:

- have a preamble of 10 symbols
- have no CRC
- have no header
- have non-inverted signal polarity

These are four differences compared to all other frame types. The current release has the header present, has the polarity inverted, and sends the standard 8 symbol preamble.

From the 1.0.3 spec:

![image](https://user-images.githubusercontent.com/3505720/140425328-c28e1c57-cce2-44e8-a500-9e26ef23d954.png)

And from the 1.0.3 regional parameters:

![image](https://user-images.githubusercontent.com/3505720/140425458-100e8836-f442-4f0d-a452-8d9e040037c3.png)

That is for AU915, but the beacon signal polarity is non-inverted in every region.