### PR TITLE
Pointing mbedtls dependency to proper branch

### DIFF
--- a/deps/mbedtls/prep.sh
+++ b/deps/mbedtls/prep.sh
@@ -30,7 +30,7 @@ set -e
 cd $(dirname $0)
 
 if [[ ! -d git-repo ]]; then
-    git clone -b mbedtls-2.6 --single-branch --depth 1 https://github.com/ARMmbed/mbedtls.git git-repo
+    git clone -b archive/mbedtls-2.6 --single-branch --depth 1 https://github.com/ARMmbed/mbedtls.git git-repo
 fi
 
 if [[ -z "$platform" ]] || [[ -z "$variant" ]]; then


### PR DESCRIPTION
This PR fixes #142.

If you decide to merge this, please consider cherry-picking the commit to the released tag branches, in order to make it able for people to actually build those.

Thanks!