### PR TITLE
Added support for Arch Linux ARM for Pi3

### DIFF
--- a/setup.gmk
+++ b/setup.gmk
@@ -40,7 +40,7 @@ variant  ?= std
 
 LOCAL_ARCH := $(shell gcc -dumpmachine)
 
-ifeq (${LOCAL_ARCH}, arm7l-unknown-linux-gnueabihf)
+ifeq (${LOCAL_ARCH},armv7l-unknown-linux-gnueabihf)
 LOCAL_ARCH = arm-linux-gnueabihf
 endif
 

--- a/setup.gmk
+++ b/setup.gmk
@@ -40,6 +40,10 @@ variant  ?= std
 
 LOCAL_ARCH := $(shell gcc -dumpmachine)
 
+ifeq (${LOCAL_ARCH}, arm7l-unknown-linux-gnueabihf)
+LOCAL_ARCH = arm-linux-gnueabihf
+endif
+
 ARCH.linux   = x86_64-linux-gnu
 ARCH.linuxV2 = x86_64-linux-gnu
 ARCH.linuxpico = x86_64-linux-gnu


### PR DESCRIPTION
I'm sure there's a waaay better way to do this. But this is my little fix to be able to compile basicstation running Arm Arch Linux on a Raspberry Pi 3. Would globing be better (arm*-linux-gnueabihf)?