### PR TITLE
Include sys/time.h to add compatibility with musl

### DIFF
--- a/src/aio.c
+++ b/src/aio.c
@@ -27,7 +27,7 @@
  */
 
 #include <unistd.h>
-#include <time.h>
+#include <sys/time.h>
 #include <errno.h>
 #include <fcntl.h>
 #include "rt.h"


### PR DESCRIPTION
Change time.h include directory to add compatibility with musl and fix
compilation error

Signed-off-by: mschref <mschref@tdt.de>